### PR TITLE
Support Git Tag Counters

### DIFF
--- a/cmd/contributions.go
+++ b/cmd/contributions.go
@@ -40,6 +40,7 @@ func main() {
 	// Gitler
 	gitlerCmd := flag.NewFlagSet("gitler", flag.ExitOnError)
 	gitlerCsvEntryFile := gitlerCmd.String("csv-file", "", "")
+	gitlerGrep := gitlerCmd.String("grep", "", "")
 
 	if len(os.Args) < 2 {
 		fmt.Println("\n🚒 pha-go does not recognize your command. ")
@@ -71,7 +72,7 @@ func main() {
 	case "gitler":
 		// Git Iterations with multiple repositories
 		gitlerCmd.Parse(os.Args[2:])
-		GitlerIteration(&confFile, gitlerCsvEntryFile)
+		GitlerIteration(&confFile, gitlerCsvEntryFile, gitlerGrep)
 
 	default:
 		fmt.Println("Error: not available.")

--- a/cmd/contributions.go
+++ b/cmd/contributions.go
@@ -37,6 +37,10 @@ func main() {
 	jenkinsRepo := jenkinsCmd.String("repo", "", "")
 	jenkinsParams := jenkinsCmd.String("params-ci", "", "")
 
+	// Gitler
+	gitlerCmd := flag.NewFlagSet("gitler", flag.ExitOnError)
+	gitlerCsvEntryFile := gitlerCmd.String("csv-file", "", "")
+
 	if len(os.Args) < 2 {
 		fmt.Println("\n🚒 pha-go does not recognize your command. ")
 		fmt.Println("It is expecting 'arc', 'jenkins' or 'help' subcommands.")
@@ -64,6 +68,10 @@ func main() {
 	case "jenkins":
 		jenkinsCmd.Parse(os.Args[2:])
 		JenkinsAction(&confFile, jenkinsBranch, jenkinsRepo, jenkinsParams, revision)
+	case "gitler":
+		// Git Iterations with multiple repositories
+		gitlerCmd.Parse(os.Args[2:])
+		GitlerIteration(&confFile, gitlerCsvEntryFile)
 
 	default:
 		fmt.Println("Error: not available.")

--- a/cmd/contributions.go
+++ b/cmd/contributions.go
@@ -40,6 +40,7 @@ func main() {
 	// Gitler
 	gitlerCmd := flag.NewFlagSet("gitler", flag.ExitOnError)
 	gitlerCsvEntryFile := gitlerCmd.String("csv-file", "", "")
+	gitlerExportFile := gitlerCmd.String("export-file", "", "")
 	gitlerGrep := gitlerCmd.String("grep", "", "")
 
 	if len(os.Args) < 2 {
@@ -72,7 +73,7 @@ func main() {
 	case "gitler":
 		// Git Iterations with multiple repositories
 		gitlerCmd.Parse(os.Args[2:])
-		GitlerIteration(&confFile, gitlerCsvEntryFile, gitlerGrep)
+		GitlerIteration(&confFile, gitlerCsvEntryFile, gitlerGrep, gitlerExportFile)
 
 	default:
 		fmt.Println("Error: not available.")

--- a/cmd/gitler.go
+++ b/cmd/gitler.go
@@ -30,7 +30,7 @@ func ReadFileWithRepos(repos string) string {
 }
 
 // Command Iterations for Counter
-func GitlerIteration(confFile *config.ConfGoPath, csvFile *string, grep *string) string {
+func GitlerIteration(confFile *config.ConfGoPath, csvFile *string, grep *string, gitlerExportFile *string) string {
 	// Try to count like this
 	//  git log --tags --simplify-by-decoration --pretty="format:%ai %d"|grep tag|grep 2021 | wc -l
 	fmt.Println("Entering in counter", *csvFile)
@@ -40,8 +40,7 @@ func GitlerIteration(confFile *config.ConfGoPath, csvFile *string, grep *string)
 	//fmt.Println("{}", reposContent)
 
 	for _, line := range strings.Split(reposContent, "\n") {
-		fmt.Println("Repo {}", line)
-		gitler.GitCloneAndCounter(&line, grep)
+		gitler.GitCloneAndCounter(&line, grep, gitlerExportFile)
 	}
 
 	return reposContent

--- a/cmd/gitler.go
+++ b/cmd/gitler.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/bastiao/contributions/config"
+)
+
+// Read List of Repositories
+func ReadFileWithRepos(repos string) string {
+	f, err := os.Open(repos)
+	if err != nil {
+		fmt.Println(err)
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	var content string
+	content = ""
+	for scanner.Scan() {
+		content = content + scanner.Text() + "\n"
+	}
+	if err := scanner.Err(); err != nil {
+		fmt.Println(err)
+	}
+	return content
+}
+
+// Command Iterations for Counter
+func GitlerIteration(confFile *config.ConfGoPath, csvFile *string) string {
+	// Try to count like this
+	//  git log --tags --simplify-by-decoration --pretty="format:%ai %d"|grep tag|grep 2021 | wc -l
+	fmt.Println("Entering in counter", *csvFile)
+	var reposContent string
+
+	reposContent = ReadFileWithRepos(*csvFile)
+	//fmt.Println("{}", reposContent)
+
+	for _, line := range strings.Split(reposContent, "\n") {
+		fmt.Println("Repo {}", line)
+		GitClone(&line)
+	}
+
+	return reposContent
+}
+func GitClone(gitRepo *string) string {
+	if err := ensureDir(".tmp"); err != nil {
+		fmt.Println("Directory creation failed with error: " + err.Error())
+		os.Exit(1)
+	}
+	cmd := exec.Command("git", "clone", *gitRepo)
+	cmd.Dir = ".tmp"
+	_, _ = cmd.Output()
+	return ""
+}
+func ensureDir(dirName string) error {
+	err := os.Mkdir(dirName, os.ModeDir)
+	if err == nil {
+		return nil
+	}
+	if os.IsExist(err) {
+		// check that the existing path is a directory
+		info, err := os.Stat(dirName)
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			return errors.New("path exists but is not a directory")
+		}
+		return nil
+	}
+	return err
+}

--- a/cmd/gitler.go
+++ b/cmd/gitler.go
@@ -2,13 +2,12 @@ package main
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/bastiao/contributions/config"
+	"github.com/bastiao/contributions/gitler"
 )
 
 // Read List of Repositories
@@ -31,7 +30,7 @@ func ReadFileWithRepos(repos string) string {
 }
 
 // Command Iterations for Counter
-func GitlerIteration(confFile *config.ConfGoPath, csvFile *string) string {
+func GitlerIteration(confFile *config.ConfGoPath, csvFile *string, grep *string) string {
 	// Try to count like this
 	//  git log --tags --simplify-by-decoration --pretty="format:%ai %d"|grep tag|grep 2021 | wc -l
 	fmt.Println("Entering in counter", *csvFile)
@@ -42,36 +41,8 @@ func GitlerIteration(confFile *config.ConfGoPath, csvFile *string) string {
 
 	for _, line := range strings.Split(reposContent, "\n") {
 		fmt.Println("Repo {}", line)
-		GitClone(&line)
+		gitler.GitCloneAndCounter(&line, grep)
 	}
 
 	return reposContent
-}
-func GitClone(gitRepo *string) string {
-	if err := ensureDir(".tmp"); err != nil {
-		fmt.Println("Directory creation failed with error: " + err.Error())
-		os.Exit(1)
-	}
-	cmd := exec.Command("git", "clone", *gitRepo)
-	cmd.Dir = ".tmp"
-	_, _ = cmd.Output()
-	return ""
-}
-func ensureDir(dirName string) error {
-	err := os.Mkdir(dirName, os.ModeDir)
-	if err == nil {
-		return nil
-	}
-	if os.IsExist(err) {
-		// check that the existing path is a directory
-		info, err := os.Stat(dirName)
-		if err != nil {
-			return err
-		}
-		if !info.IsDir() {
-			return errors.New("path exists but is not a directory")
-		}
-		return nil
-	}
-	return err
 }

--- a/gitler/commands.go
+++ b/gitler/commands.go
@@ -1,0 +1,25 @@
+package gitler
+
+import (
+	"errors"
+	"os"
+)
+
+func ensureDir(dirName string) error {
+	err := os.Mkdir(dirName, os.ModeDir)
+	if err == nil {
+		return nil
+	}
+	if os.IsExist(err) {
+		// check that the existing path is a directory
+		info, err := os.Stat(dirName)
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			return errors.New("path exists but is not a directory")
+		}
+		return nil
+	}
+	return err
+}

--- a/gitler/gitler.go
+++ b/gitler/gitler.go
@@ -1,0 +1,52 @@
+package gitler
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// Git Clone and Counter
+func GitCloneAndCounter(gitRepo *string, grep *string) string {
+	if err := ensureDir(".tmp"); err != nil {
+		fmt.Println("Directory creation failed with error: " + err.Error())
+		os.Exit(1)
+	}
+	var dirName string
+	fmt.Println(dirName)
+	dirName = strings.Replace(*gitRepo, ".git", "", -1)
+	fmt.Println(dirName)
+	var dirs []string
+	dirs = strings.Split(dirName, "/")
+	dirName = dirs[len(dirs)-1]
+	fmt.Println(dirName)
+	cmd := exec.Command("git", "clone", *gitRepo)
+	cmd.Dir = ".tmp"
+	_, _ = cmd.Output()
+
+	cmd2 := exec.Command("git", "log", "--tags", "--simplify-by-decoration", "--pretty='format:%ai %d'")
+	cmd2.Dir = ".tmp/" + dirName
+	output, err := cmd2.Output()
+	if err != nil {
+		return "nil"
+	}
+	//myString := string(output)
+	lineBytes := bytes.Split(output, []byte{'\n'})
+	// The last split is just an empty string, right?
+	lineBytes = lineBytes[0 : len(lineBytes)-1]
+	tags := make([]*Tag, len(lineBytes))
+
+	for x := 0; x < len(lineBytes); x++ {
+		tag, tagErr := ParseTag(".tmp/"+dirName, string(lineBytes[x]), *grep)
+		if tagErr != nil {
+			return "error"
+		}
+		tags[x] = tag
+	}
+
+	//fmt.Println("out:", myString)
+
+	return ""
+}

--- a/gitler/tags.go
+++ b/gitler/tags.go
@@ -1,0 +1,36 @@
+package gitler
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Tag
+type Tag struct {
+	Hash      string
+	Author    string
+	Email     string
+	Version   string
+	Timestamp int
+}
+
+func (tag *Tag) String() string {
+	return fmt.Sprintf("\n+ Hash: %s\n| Author: %s <%s>\n|"+
+		"| Timestamp: %d\n| Email: %s\n", tag.Hash, tag.Author,
+		tag.Timestamp, tag.Email)
+}
+
+// Parse Git Tag
+func ParseTag(path, line string, filter string) (*Tag, error) {
+	//fmt.Println(line)
+	if strings.Contains(line, filter) && // contains filter
+		strings.Contains(line, "(tag: ") { // also is also a git tag
+		// Contains the filters, so let's parse
+		tagTmp := strings.Split(line, "(tag: ")
+		tagStr := strings.ReplaceAll(tagTmp[1], ")'", "")
+		tagStr = strings.Split(tagStr, ",")[0]
+		fmt.Println("Tag: ", tagStr)
+	}
+	tag := &Tag{}
+	return tag, nil
+}

--- a/gitler/tags.go
+++ b/gitler/tags.go
@@ -1,6 +1,7 @@
 package gitler
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -30,7 +31,11 @@ func ParseTag(path, line string, filter string) (*Tag, error) {
 		tagStr := strings.ReplaceAll(tagTmp[1], ")'", "")
 		tagStr = strings.Split(tagStr, ",")[0]
 		fmt.Println("Tag: ", tagStr)
+		// TODO: parse it
+		tag := &Tag{}
+		return tag, nil
 	}
+
 	tag := &Tag{}
-	return tag, nil
+	return tag, errors.New("No tag for filter or available")
 }

--- a/gitler/tags.go
+++ b/gitler/tags.go
@@ -23,8 +23,7 @@ func (tag *Tag) String() string {
 
 // Parse Git Tag
 func ParseTag(path, line string, filter string) (*Tag, error) {
-	//fmt.Println(line)
-	if strings.Contains(line, filter) && // contains filter
+	if contains(strings.Split(filter, "|"), line) && // contains filter
 		strings.Contains(line, "(tag: ") { // also is also a git tag
 		// Contains the filters, so let's parse
 		tagTmp := strings.Split(line, "(tag: ")
@@ -38,4 +37,13 @@ func ParseTag(path, line string, filter string) (*Tag, error) {
 
 	tag := &Tag{}
 	return tag, errors.New("No tag for filter or available")
+}
+
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if strings.Contains(e, a) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Support Git Tag Counters #4

Some examples to run: 
```
go run cmd/*.go gitler --csv-file="repos.txt" --grep="2021-10|2021-11|2021-12" --export-file="repos-tags.txt"
```
